### PR TITLE
Reconnect to database on each query

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "author": "Michael Keller",
   "license": "MIT",
   "dependencies": {
-    "underscore": ">=1.5.2",
-    "pg": "~4.3.0",
     "colors": "~0.6.2",
-    "sqlite3": "~3.0.5",
+    "dsv": "~0.0.3",
     "optimist": "~0.6.0",
-    "dsv": "~0.0.3"
+    "pg": "~4.3.0",
+    "sqlite3": "~3.0.5",
+    "underscore": ">=1.5.2"
   },
   "bugs": {
     "url": "https://github.com/ajam/tablespoon/issues"

--- a/src/pgsql.js
+++ b/src/pgsql.js
@@ -3,8 +3,9 @@ var colors = require('colors');
 
 
 var client,
-		err_preview_length = 100,
-		connected = false;
+    connection_string,
+    err_preview_length = 100,
+    connected = false;
 
 var helpers = {
 	handleErr: function(err, msg, qt){
@@ -21,7 +22,8 @@ var helpers = {
 	}
 }
 
-function connectToDb(connection_string){
+function connectToDb(con_string){
+    connection_string = con_string;
 	client = client || new Client(connection_string);
 	//disconnect client when all queries are finished
   client.on('drain', client.end.bind(client)); 
@@ -50,13 +52,21 @@ function insertInto(insert_commands){
 }
 
 function query(query_text, cb){
-	var result_obj = {}
-  client.query(query_text, function(err, result){
-  	helpers.handleErr(err, 'query', query_text)
-  	result_obj.query = query_text;
-  	result_obj.rows  = result.rows
-  	cb(result_obj);
-  })
+    // TODO but with pooling!
+	client = new Client(connection_string);
+    client.connect(function (err) {
+        if (err) {
+            console.error(err);
+            return;
+        }
+        var result_obj = {};
+        client.query(query_text, function(err, result){
+            helpers.handleErr(err, 'query', query_text);
+            result_obj.query = query_text;
+            result_obj.rows  = result.rows;
+            cb(result_obj);
+        });
+    });
 }
 function queries(query_texts, cb){
 	var results = [],


### PR DESCRIPTION
I'm not sure if this is the best way to do this, but while working on a desktop client using electron and trying to make a query after a form is submitted (containing the query), I kept getting an error that the socket had been closed. Reconnecting to the database as we do here seems to fix it, but I'm very much open to other solutions.
